### PR TITLE
Yarn cache

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -25,6 +25,10 @@ jobs:
       - name: Bygg (yarn run build)
         run: yarn run build
 
+      # Cache docker images
+      - uses: satackey/action-docker-layer-caching@v0.0.11
+        continue-on-error: true
+
       - name: Bygg, tag og push Docker-image
         run: |
           docker build --tag $APP_IMAGE .

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -13,7 +13,18 @@ jobs:
       - name: Sjekk ut kode
         uses: actions/checkout@v2
 
-      - uses: c-hive/gha-yarn-cache@v1
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Cache yarn-avhengigheter
+        uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
       - name: Installer avhengigheter (yarn ci)
         run: |

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -25,10 +25,6 @@ jobs:
       - name: Bygg (yarn run build)
         run: yarn run build
 
-      # Cache docker images
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-
       - name: Bygg, tag og push Docker-image
         run: |
           docker build --tag $APP_IMAGE .
@@ -73,5 +69,4 @@ jobs:
                 VARS: nais/prod-env.yaml
                 IMAGE: ${{ env.APP_IMAGE }}
                 REF: ${{ env.COMMIT }}
-
 

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -77,7 +77,7 @@ jobs:
       name: Deploy to dev-sbs
       # Redigér her hvis du vil deploye en branch til dev. F.eks. slik:
       # if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/<navn-på-branch>'
-      if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/docker-image-cache'
+      if: github.ref == 'refs/heads/master' 
       needs: compile-test-and-build
       runs-on: ubuntu-latest
       steps:

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -13,6 +13,8 @@ jobs:
       - name: Sjekk ut kode
         uses: actions/checkout@v2
 
+      - uses: c-hive/gha-yarn-cache@v1
+
       - name: Installer avhengigheter (yarn ci)
         run: |
           yarn install --frozen-lockfile

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -74,3 +74,4 @@ jobs:
                 IMAGE: ${{ env.APP_IMAGE }}
                 REF: ${{ env.COMMIT }}
 
+


### PR DESCRIPTION
Cacher yarn-greier. Bruker c-hive/gha-yarn-cache@v1, men kunne nok også ha gjort det selv med litt flere linjer.
Det ser ut til å ha en viss effekt på _yarn install_-steget, men selve cache-steget tar også litt tid.