### PR TITLE
Bruk dayjs i Datovelger-komponenten

### DIFF
--- a/src/dayjs-config.ts
+++ b/src/dayjs-config.ts
@@ -1,6 +1,8 @@
 import dayjs from 'dayjs';
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import isBetween from 'dayjs/plugin/isBetween';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
 
 dayjs.extend(isSameOrAfter);
 dayjs.extend(isBetween);
+dayjs.extend(customParseFormat);

--- a/src/dayjs-config.ts
+++ b/src/dayjs-config.ts
@@ -3,6 +3,8 @@ import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import isBetween from 'dayjs/plugin/isBetween';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 
-dayjs.extend(isSameOrAfter);
-dayjs.extend(isBetween);
-dayjs.extend(customParseFormat);
+export const configureDayJS = () => {
+    dayjs.extend(isSameOrAfter);
+    dayjs.extend(isBetween);
+    dayjs.extend(customParseFormat);
+};

--- a/src/dayjs-config.ts
+++ b/src/dayjs-config.ts
@@ -1,0 +1,6 @@
+import dayjs from 'dayjs';
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
+import isBetween from 'dayjs/plugin/isBetween';
+
+dayjs.extend(isSameOrAfter);
+dayjs.extend(isBetween);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,9 @@ import './index.css';
 import './index.less';
 import App from './App';
 import NavFrontendSpinner from 'nav-frontend-spinner';
-import './dayjs-config';
+import { configureDayJS } from './dayjs-config';
+
+configureDayJS();
 
 ReactDOM.render(
     <Suspense fallback={<NavFrontendSpinner />}>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import './index.css';
 import './index.less';
 import App from './App';
 import NavFrontendSpinner from 'nav-frontend-spinner';
+import './dayjs-config';
 
 ReactDOM.render(
     <Suspense fallback={<NavFrontendSpinner />}>

--- a/src/komponenter/ContextProvider.tsx
+++ b/src/komponenter/ContextProvider.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import dayjs from 'dayjs';
+import React, { useEffect, useRef, useState } from 'react';
+import dayjs, { Dayjs } from 'dayjs';
 import { SanityBlockTypes, SistOppdatert } from '../sanity-blocks/sanityTypes';
 import { fetchsanityJSON, isProduction } from '../utils/fetch-utils';
 import { skrivTilMalingBesokerSide } from '../utils/amplitudeUtils';
@@ -24,6 +24,7 @@ export interface Context {
     settPermitteringInnhold: SettPermitteringInnhold;
     setSideSistOppdatert: SettSideSistOppdatert;
     dagensDato: Date;
+    dagensDatoDayjs: Dayjs;
 }
 
 export const PermitteringContext = React.createContext({} as Context);
@@ -39,6 +40,8 @@ const ContextProvider = (props: Props) => {
     const [sistOppdatert, setSistOppdatert] = useState<SistOppdatert | null>(
         null
     );
+
+    const [dagensDato] = useState<Dayjs>(dayjs().startOf('date'));
 
     const settPermitteringInnhold = <
         K extends keyof NonNullable<PermitteringInnhold>,
@@ -62,7 +65,8 @@ const ContextProvider = (props: Props) => {
         sistOppdatert,
         settPermitteringInnhold,
         setSideSistOppdatert,
-        dagensDato: dayjs().startOf('date').toDate(),
+        dagensDato: dagensDato.toDate(),
+        dagensDatoDayjs: dagensDato,
     };
 
     useEffect(() => {

--- a/src/komponenter/ContextProvider.tsx
+++ b/src/komponenter/ContextProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import dayjs, { Dayjs } from 'dayjs';
 import { SanityBlockTypes, SistOppdatert } from '../sanity-blocks/sanityTypes';
 import { fetchsanityJSON, isProduction } from '../utils/fetch-utils';
@@ -7,9 +7,9 @@ import { scrollIntoView } from '../utils/scrollIntoView';
 import { setEnv } from '../sanity-blocks/serializer';
 import {
     PermitteringInnhold,
+    setPermitteringInnholdFraNokkelVerdi,
     SettPermitteringInnhold,
     SettSideSistOppdatert,
-    setPermitteringInnholdFraNokkelVerdi,
 } from './ContextTypes';
 
 interface Props {

--- a/src/komponenter/Datovelger/Datovelger.tsx
+++ b/src/komponenter/Datovelger/Datovelger.tsx
@@ -75,7 +75,6 @@ const Datovelger: FunctionComponent<Props> = (props) => {
     const inputOnBlur = (event: any) => {
         setEditing(false);
         const newDato = dayjs(event.currentTarget.value, 'DD.MM.YYYY');
-        // TODO test
         if (newDato.isValid()) {
             onDatoClick(newDato);
         } else {

--- a/src/komponenter/Datovelger/datofunksjoner-dayjs.tsx
+++ b/src/komponenter/Datovelger/datofunksjoner-dayjs.tsx
@@ -1,34 +1,6 @@
 import { Dayjs } from 'dayjs';
 
-export const skrivOmDato = (dato?: Date) => {
-    if (dato) {
-        const year = dato.getFullYear().toString();
-        let day = dato.getDate().toString();
-        let month = (dato.getMonth() + 1).toString();
-        if (day.length < 2) {
-            day = '0' + day;
-        }
-        if (month.length < 2) {
-            month = '0' + month;
-        }
-        return day + '.' + month + '.' + year;
-    }
-    return '';
-};
-
 export const formaterDato = (dato: Dayjs): string => dato.format('DD.MM.YYYY');
-
-export const skrivOmDatoStreng = (datoStreng: string) => {
-    const parts = datoStreng.split('.');
-    const year = parseInt(parts[2]);
-    const month = parseInt(parts[1]);
-    const day = parseInt(parts[0]);
-    if (year > 1970 && month > 0 && day > 0) {
-        return new Date(year, month - 1, day);
-    } else {
-        return false;
-    }
-};
 
 export const datoValidering = (day?: Dayjs, after?: Dayjs, before?: Dayjs) => {
     if (day) {
@@ -45,40 +17,4 @@ export const datoValidering = (day?: Dayjs, after?: Dayjs, before?: Dayjs) => {
     }
 
     return '';
-};
-
-export const WEEKDAYS_SHORT = {
-    no: ['Sø', 'Ma', 'Ti', 'On', 'To', 'Fr', 'Lø'],
-};
-export const MONTHS = {
-    no: [
-        'Januar',
-        'Februar',
-        'Mars',
-        'April',
-        'Mai',
-        'Juni',
-        'Juli',
-        'August',
-        'September',
-        'Oktober',
-        'November',
-        'Desember',
-    ],
-};
-
-export const WEEKDAYS_LONG = {
-    no: [
-        'Mandag',
-        'Tirsdag',
-        'Onsdag',
-        'Torsdag',
-        'Fredag',
-        'Lørdag',
-        'Søndag',
-    ],
-};
-
-export const LABELS = {
-    no: { nextMonth: 'Neste måned', previousMonth: 'Forrige måned' },
 };

--- a/src/komponenter/Datovelger/datofunksjoner-dayjs.tsx
+++ b/src/komponenter/Datovelger/datofunksjoner-dayjs.tsx
@@ -16,6 +16,8 @@ export const skrivOmDato = (dato?: Date) => {
     return '';
 };
 
+export const formaterDato = (dato: Dayjs): string => dato.format('DD.MM.YYYY');
+
 export const skrivOmDatoStreng = (datoStreng: string) => {
     const parts = datoStreng.split('.');
     const year = parseInt(parts[2]);
@@ -28,15 +30,15 @@ export const skrivOmDatoStreng = (datoStreng: string) => {
     }
 };
 
-export const datoValidering = (day?: Date, after?: Date, before?: Date) => {
+export const datoValidering = (day?: Dayjs, after?: Dayjs, before?: Dayjs) => {
     if (day) {
         if (after) {
-            if (day.getTime() < after.getTime()) {
+            if (day.isBefore(after)) {
                 return 'Til-dato må være etter fra-dato';
             }
         }
         if (before) {
-            if (day.getTime() > before.getTime()) {
+            if (day.isAfter(before)) {
                 return 'Fra-dato må være før til-dato';
             }
         }

--- a/src/komponenter/Datovelger/datofunksjoner.tsx
+++ b/src/komponenter/Datovelger/datofunksjoner.tsx
@@ -1,5 +1,3 @@
-import { Dayjs } from 'dayjs';
-
 export const skrivOmDato = (dato?: Date) => {
     if (dato) {
         const year = dato.getFullYear().toString();

--- a/src/komponenter/kalkulator/DatointervallInput/DatointervallInput.tsx
+++ b/src/komponenter/kalkulator/DatointervallInput/DatointervallInput.tsx
@@ -5,6 +5,7 @@ import { ARBEIDSGIVERPERIODE2DATO, finn1DagFram } from '../utregninger';
 import Datovelger from '../../Datovelger/Datovelger';
 import { Checkbox } from 'nav-frontend-skjema';
 import Lukknapp from 'nav-frontend-lukknapp';
+import dayjs from 'dayjs';
 
 interface Props {
     datoIntervall: DatoIntervall;
@@ -61,18 +62,22 @@ const DatoIntervallInput: FunctionComponent<Props> = (props) => {
             <div className="datointervall-input__dato-wrapper">
                 <Datovelger
                     className="datointervall-input__datoinput"
-                    value={datoIntervall.datoFra}
+                    value={dayjs(datoIntervall.datoFra)}
                     onChange={onFraDatoChange}
-                    skalVareFoer={datoIntervall.datoTil}
+                    skalVareFoer={dayjs(datoIntervall.datoTil)}
                     overtekst="Første dag"
                 />
                 <Datovelger
                     className="datointervall-input__datoinput"
-                    value={datoIntervall.datoTil}
-                    onChange={(event) => setTilDato(event.currentTarget.value)}
+                    value={
+                        datoIntervall.datoTil && dayjs(datoIntervall.datoTil)
+                    }
+                    onChange={(event) =>
+                        setTilDato(event.currentTarget.value.toDate())
+                    }
                     disabled={erLøpende}
                     overtekst="Siste dag"
-                    skalVareEtter={datoIntervall.datoFra}
+                    skalVareEtter={dayjs(datoIntervall.datoFra)}
                 />
             </div>
             <Checkbox

--- a/src/komponenter/kalkulator/DatointervallInput/DatointervallInput.tsx
+++ b/src/komponenter/kalkulator/DatointervallInput/DatointervallInput.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import './DatointervallInput.less';
 import { DatoIntervall } from '../typer';
-import { ARBEIDSGIVERPERIODE2DATO, finn1DagFram } from '../utregninger';
+import { ARBEIDSGIVERPERIODE2DATO } from '../utregninger';
 import Datovelger from '../../Datovelger/Datovelger';
 import { Checkbox } from 'nav-frontend-skjema';
 import Lukknapp from 'nav-frontend-lukknapp';

--- a/src/komponenter/kalkulator/DatointervallInput/DatointervallInput.tsx
+++ b/src/komponenter/kalkulator/DatointervallInput/DatointervallInput.tsx
@@ -5,7 +5,7 @@ import { ARBEIDSGIVERPERIODE2DATO, finn1DagFram } from '../utregninger';
 import Datovelger from '../../Datovelger/Datovelger';
 import { Checkbox } from 'nav-frontend-skjema';
 import Lukknapp from 'nav-frontend-lukknapp';
-import dayjs from 'dayjs';
+import dayjs, { Dayjs } from 'dayjs';
 
 interface Props {
     datoIntervall: DatoIntervall;
@@ -24,16 +24,16 @@ const DatoIntervallInput: FunctionComponent<Props> = (props) => {
             datoTil: dato,
         });
 
-    const onFraDatoChange = (event: any) => {
-        const eventDato: Date = event.currentTarget.value;
+    const onFraDatoChange = (event: { currentTarget: { value: Dayjs } }) => {
+        const eventDato: Dayjs = event.currentTarget.value;
 
         const nyttDatoIntervall = !!datoIntervall.datoTil
             ? {
-                  datoFra: eventDato,
+                  datoFra: eventDato.toDate(),
               }
             : {
-                  datoFra: eventDato,
-                  datoTil: finn1DagFram(eventDato),
+                  datoFra: eventDato.toDate(),
+                  datoTil: eventDato.add(1, 'day').toDate(),
               };
 
         setDatoIntervall({

--- a/src/komponenter/kalkulator/Topp/Topp.tsx
+++ b/src/komponenter/kalkulator/Topp/Topp.tsx
@@ -11,6 +11,7 @@ import Datovelger from '../../Datovelger/Datovelger';
 import kalender from './kalender.svg';
 import Lenke from 'nav-frontend-lenker';
 import { PermitteringContext } from '../../ContextProvider';
+import dayjs, { Dayjs } from 'dayjs';
 
 interface Props {
     set18mndsPeriode: (dato: Date) => void;
@@ -23,7 +24,8 @@ const Topp: FunctionComponent<Props> = (props) => {
     const [feilMelding, setFeilmelding] = useState('');
     const { dagensDato } = useContext(PermitteringContext);
 
-    const datoValidering = (dato: Date) => {
+    const datoValidering = (datoDayjs: Dayjs) => {
+        const dato = datoDayjs.toDate();
         if (dato >= finnGrenserFor18MNDPeriode(dagensDato).datoTil!!) {
             setFeilmelding(
                 'sett dato før ' +
@@ -88,11 +90,13 @@ const Topp: FunctionComponent<Props> = (props) => {
                     overtekst={'Siste dag i perioden'}
                     onChange={(event) => {
                         if (datoValidering(event.currentTarget.value)) {
-                            props.set18mndsPeriode(event.currentTarget.value);
+                            props.set18mndsPeriode(
+                                event.currentTarget.value.toDate()
+                            );
                             props.setEndringAv('datovelger');
                         }
                     }}
-                    value={props.sisteDagIPeriode}
+                    value={dayjs(props.sisteDagIPeriode)}
                 />
             </div>
             <div className={'kalkulator__velg-ny-periode-info'}>


### PR DESCRIPTION
Strategi for å migrere til Dayjs:
 - Dupliser dagensDato i context - én Date og én Dayjs.
 - Komponent for komponent, gå over fra å bruke Date til Dayjs fra context.
 - Hvis komponentene bruker funksjoner som belager seg på Date, migrer disse funksjonene også.
 - Til slutt, slett utdatert Date-context og fjern ubrukte Date-funksjoner.

